### PR TITLE
v1.0.3

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - 'MWG.EyesOfApollo.Desktop/**'
       - 'Themes/**'
-      - '.github/workflows/build-publish.yml'
   workflow_dispatch:
     inputs:
       force_release:

--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -18,9 +18,9 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 10.0.x
-      - name: Install MAUI Workloads
-        run: dotnet workload install maui-android maui-windows
-      - name: Restore
+      - name: Restore Workloads
+        run: dotnet workload restore
+      - name: Restore Packages
         run: dotnet restore MWG.EyesOfApollo.Tests/MWG.EyesOfApollo.Tests.csproj
       - name: Test
         run: dotnet test MWG.EyesOfApollo.Tests/MWG.EyesOfApollo.Tests.csproj -c Release --no-restore

--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -18,6 +18,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 10.0.x
+      - name: Install MAUI Workloads
+        run: dotnet workload install maui-android maui-windows
       - name: Restore
         run: dotnet restore MWG.EyesOfApollo.Tests/MWG.EyesOfApollo.Tests.csproj
       - name: Test

--- a/MWG.EyesOfApollo.Desktop/MWG.EyesOfApollo.Desktop.csproj
+++ b/MWG.EyesOfApollo.Desktop/MWG.EyesOfApollo.Desktop.csproj
@@ -25,8 +25,8 @@
 		<ApplicationId>com.mw-gc.eyesofapollo.desktop</ApplicationId>
 
 		<!-- Versions -->
-		<ApplicationDisplayVersion>1.0.2</ApplicationDisplayVersion>
-		<ApplicationVersion>102</ApplicationVersion>
+		<ApplicationDisplayVersion>1.0.3</ApplicationDisplayVersion>
+		<ApplicationVersion>103</ApplicationVersion>
 
 		<!-- To develop, package, and publish an app to the Microsoft Store, see: https://aka.ms/MauiTemplateUnpackaged -->
 		<WindowsPackageType>MSIX</WindowsPackageType>

--- a/MWG.EyesOfApollo.Desktop/Platforms/Android/AndroidManifest.xml
+++ b/MWG.EyesOfApollo.Desktop/Platforms/Android/AndroidManifest.xml
@@ -3,4 +3,5 @@
 	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />
+	<uses-permission android:name="android.permission.RECORD_AUDIO" />
 </manifest>

--- a/MWG.EyesOfApollo.Desktop/Services/AudioCaptureService.Android.cs
+++ b/MWG.EyesOfApollo.Desktop/Services/AudioCaptureService.Android.cs
@@ -1,0 +1,208 @@
+#if ANDROID
+using Android.Content;
+using Android.Media;
+using System.Diagnostics;
+using MauiAudioDeviceInfo = MWG.EyesOfApollo.Desktop.Models.AudioDeviceInfo;
+
+namespace MWG.EyesOfApollo.Desktop.Services
+{
+    /// <summary>
+    /// Android-specific audio capture implementation using AudioRecord and AudioManager.
+    /// </summary>
+    public partial class AudioCaptureService
+    {
+        // Minimum reasonable PCM buffer size in bytes when the platform reports an invalid minimum.
+        private const int FallbackBufferSize = 4096;
+        // Number of audio channels matching ChannelIn.Stereo.
+        private const int StereoChannels = 2;
+        // Divisor used to normalise a 16-bit signed PCM sample to the [-1, 1] range.
+        private const float Pcm16MaxAmplitude = 32768f;
+
+        private AudioRecord? _audioRecord;
+        private CancellationTokenSource? _captureCts;
+        private Task? _captureTask;
+
+        /// <inheritdoc />
+        public Task<IReadOnlyList<MauiAudioDeviceInfo>> GetInputDevicesAsync()
+        {
+            var devices = new List<MauiAudioDeviceInfo>();
+
+            if (OperatingSystem.IsAndroidVersionAtLeast(23))
+            {
+                var audioManager = Android.App.Application.Context.GetSystemService(Context.AudioService) as AudioManager;
+                var androidDevices = audioManager?.GetDevices(GetDevicesTargets.Inputs);
+                if (androidDevices != null)
+                {
+                    foreach (var d in androidDevices)
+                    {
+                        devices.Add(new MauiAudioDeviceInfo(d.Id.ToString(), $"{d.ProductName} ({d.Type})"));
+                    }
+                }
+            }
+
+            if (devices.Count == 0)
+            {
+                devices.Add(new MauiAudioDeviceInfo("0", "Default Microphone"));
+            }
+
+            return Task.FromResult<IReadOnlyList<MauiAudioDeviceInfo>>(devices);
+        }
+
+        /// <inheritdoc />
+        public Task<IReadOnlyList<MauiAudioDeviceInfo>> GetOutputDevicesAsync()
+        {
+            var devices = new List<MauiAudioDeviceInfo>();
+
+            if (OperatingSystem.IsAndroidVersionAtLeast(23))
+            {
+                var audioManager = Android.App.Application.Context.GetSystemService(Context.AudioService) as AudioManager;
+                var androidDevices = audioManager?.GetDevices(GetDevicesTargets.Outputs);
+                if (androidDevices != null)
+                {
+                    foreach (var d in androidDevices)
+                    {
+                        devices.Add(new MauiAudioDeviceInfo(d.Id.ToString(), $"{d.ProductName} ({d.Type})"));
+                    }
+                }
+            }
+
+            if (devices.Count == 0)
+            {
+                devices.Add(new MauiAudioDeviceInfo("0", "Default Speaker"));
+            }
+
+            return Task.FromResult<IReadOnlyList<MauiAudioDeviceInfo>>(devices);
+        }
+
+        /// <inheritdoc />
+        public async Task StartAsync(MauiAudioDeviceInfo device, Models.AudioSourceType sourceType)
+        {
+            await StopAsync();
+
+            if (sourceType == Models.AudioSourceType.Input)
+            {
+                const int sampleRate = 44100;
+                const ChannelIn channelConfig = ChannelIn.Stereo;
+                const Encoding audioFormat = Encoding.Pcm16bit;
+
+                var bufferSize = AudioRecord.GetMinBufferSize(sampleRate, channelConfig, audioFormat);
+                if (bufferSize <= 0)
+                {
+                    bufferSize = FallbackBufferSize;
+                }
+
+                _audioRecord = new AudioRecord(AudioSource.Mic, sampleRate, channelConfig, audioFormat, bufferSize);
+
+                if (OperatingSystem.IsAndroidVersionAtLeast(23) && device.Id != "0")
+                {
+                    if (int.TryParse(device.Id, out var deviceId))
+                    {
+                        var audioManager = Android.App.Application.Context.GetSystemService(Context.AudioService) as AudioManager;
+                        var androidDevices = audioManager?.GetDevices(GetDevicesTargets.Inputs);
+                        if (androidDevices != null)
+                        {
+                            foreach (var d in androidDevices)
+                            {
+                                if (d.Id == deviceId)
+                                {
+                                    _audioRecord.SetPreferredDevice(d);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (_audioRecord.State != Android.Media.State.Initialized)
+                {
+                    _audioRecord.Release();
+                    _audioRecord.Dispose();
+                    _audioRecord = null;
+                    IsRunning = false;
+                    return;
+                }
+
+                _audioRecord.StartRecording();
+                IsRunning = true;
+
+                _captureCts = new CancellationTokenSource();
+                var token = _captureCts.Token;
+                var localRecord = _audioRecord;
+                var capturedSampleRate = sampleRate;
+                var buffer = new byte[bufferSize];
+
+                _captureTask = Task.Run(() =>
+                {
+                    try
+                    {
+                        while (!token.IsCancellationRequested)
+                        {
+                            var read = localRecord?.Read(buffer, 0, buffer.Length) ?? -1;
+                            if (read <= 0)
+                            {
+                                break;
+                            }
+
+                            var samples = ConvertPcm16ToFloat(buffer, read);
+                            RaiseBuffer(samples, capturedSampleRate, StereoChannels, Stopwatch.GetTimestamp(), sourceType);
+                        }
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // Expected on cancellation; suppress.
+                    }
+                }, token);
+            }
+            else
+            {
+                // System-wide output loopback capture is not available on Android without
+                // special OEM or root permissions. Devices are listed for UI selection only.
+                IsRunning = false;
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task StopAsync()
+        {
+            _captureCts?.Cancel();
+
+            if (_captureTask != null)
+            {
+                try
+                {
+                    await _captureTask.ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Expected on cancellation; suppress.
+                }
+
+                _captureTask = null;
+            }
+
+            _captureCts?.Dispose();
+            _captureCts = null;
+
+            _audioRecord?.Stop();
+            _audioRecord?.Release();
+            _audioRecord?.Dispose();
+            _audioRecord = null;
+
+            IsRunning = false;
+        }
+
+        private static float[] ConvertPcm16ToFloat(byte[] buffer, int bytesRead)
+        {
+            var sampleCount = bytesRead / sizeof(short);
+            var samples = new float[sampleCount];
+            for (var i = 0; i < sampleCount; i++)
+            {
+                var sample = BitConverter.ToInt16(buffer, i * sizeof(short));
+                samples[i] = sample / Pcm16MaxAmplitude;
+            }
+
+            return samples;
+        }
+    }
+}
+#endif

--- a/MWG.EyesOfApollo.Desktop/Services/AudioCaptureService.Other.cs
+++ b/MWG.EyesOfApollo.Desktop/Services/AudioCaptureService.Other.cs
@@ -1,4 +1,4 @@
-#if !WINDOWS
+#if !WINDOWS && !ANDROID
 using MWG.EyesOfApollo.Desktop.Models;
 
 namespace MWG.EyesOfApollo.Desktop.Services


### PR DESCRIPTION
This pull request adds Android audio capture support to the project, updates the Android permissions, and increments the application version. The main focus is on enabling microphone input capture on Android devices with proper device selection and permission handling.

**Android audio capture implementation:**

* Added a new partial class `AudioCaptureService.Android.cs` that implements audio input capture for Android using `AudioRecord`, including device enumeration, buffer handling, and cancellation support. This enables the app to access and process microphone input on Android devices.
* Updated `AudioCaptureService.Other.cs` preprocessor condition to exclude Android, ensuring the correct platform-specific implementation is used.

**Android permissions:**

* Added the `android.permission.RECORD_AUDIO` permission to `AndroidManifest.xml` to allow the app to access the microphone on Android devices.

**Build and versioning:**

* Updated the application version and display version in `MWG.EyesOfApollo.Desktop.csproj` from 1.0.2 (102) to 1.0.3 (103).

**Workflow configuration:**

* Removed `.github/workflows/build-publish.yml` from the workflow trigger paths to prevent unnecessary workflow runs on changes to the workflow file itself.